### PR TITLE
Feature/documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+on:
+  push:
+    tags:
+      - 'v*'
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: InfluxdbV2_${{ github.ref }}
+          release_name: Influxdb_v2 ${{ github.ref }}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -1,0 +1,26 @@
+---
+layout: "influxdb"
+page_title: "Provider: InfluxDB"
+sidebar_current: "docs-influxdb-index"
+description: |-
+  The InfluxDB provider configures databases, etc on an InfluxDB server.
+---
+
+# InfluxDB V2 Provider
+
+The InfluxDB provider allows Terraform to create Databases in
+[InfluxDB](https://influxdb.com/). InfluxDB is a database server optimized
+for time-series data.
+
+The provider configuration block accepts the following arguments:
+
+* ``url`` - (Optional) The root URL of a InfluxDB V2 server. May alternatively be
+  set via the ``INFLUXDB_URL`` environment variable. Defaults to
+  `http://localhost:9999/`.
+  
+## Example Usage
+
+```hcl
+provider "influxdb" {
+  url      = "http://influxdb.example.com:9999"
+}

--- a/website/influxdbv2.erb
+++ b/website/influxdbv2.erb
@@ -1,0 +1,22 @@
+<% wrap_layout :inner do %>
+  <% content_for :sidebar do %>
+    <div class="docs-sidebar hidden-print affix-top" role="complementary">
+      <ul class="nav docs-sidenav">
+        <li<%= sidebar_current("docs-home") %>>
+          <a href="/docs/providers/index.html">All Providers</a>
+        </li>
+
+        <li<%= sidebar_current("docs-influxdb-index") %>>
+          <a href="/docs/providers/influxdb/index.html">InfluxDB V2 Provider</a>
+        </li>
+
+        <li<%= sidebar_current("docs-influxdb-resource") %>>
+          <a href="#">Resources</a>
+
+        </li>
+      </ul>
+    </div>
+  <% end %>
+
+  <%= yield %>
+<% end %>


### PR DESCRIPTION
Minimal documentation for the current provider version. The current documentation explains how to use the provider with setting up the influxdb url. 
Closes #3 