### PR TITLE
Refactoring provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ go test ./influxdbv2
 ## How to use
 
 ### Initialize the provider
+
+If you already setup the initial onboarding screen, it is necessary to get the access token and set it up like below.
 ```hcl
 provider "influxdbv2" {
   url = "http://influxdb.example.com:9999"
-  username = "influxdbUsername"
-  password = "influxdbPassword"
   token = "influxdbToken"
 }
+```
 
- ```
+If you need to setup the onboarding screen, you should use the provider created for that. To use it, see the documentation [here](https://github.com/lancey-energy-storage/terraform-provider-influxdb-v2-onboarding)
 
 ### Get /ready informations
 

--- a/examples/test.tf
+++ b/examples/test.tf
@@ -1,6 +1,31 @@
+provider "influxdbv2-onboarding" {
+    url = "http://localhost:9999"
+    username = "test"
+    password = "test1234"
+}
+
+resource "influxdbv2-onboarding_setup" "setup" {
+    bucket = "test-bucket"
+    org = "test-org"
+    retention_period = 4
+}
+
 provider "influxdbv2" {
     url = "http://localhost:9999"
-    username = "influxdbUsername"
-    password = "influxdbPassword"
-    token = "influxdbToken"
+    token = influxdbv2-onboarding_setup.setup.token
+}
+
+
+data "influxdbv2_ready" "test" {}
+
+output "influxdbv2_ready" {
+    value = data.influxdbv2_ready.test.output["status"]
+}
+
+output "ready_started" {
+    value = data.influxdbv2_ready.test.output["started"]
+}
+
+output "ready_up" {
+    value = data.influxdbv2_ready.test.output["up"]
 }

--- a/influxdbv2/provider.go
+++ b/influxdbv2/provider.go
@@ -19,21 +19,10 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_V2_URL", "http://localhost:9999"),
 			},
-			"username": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_V2_USERNAME", ""),
-			},
-			"password": {
+			"token": {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_V2_PASSWORD", ""),
-			},
-			"token": {
-				Type: schema.TypeString,
-				Optional: true,
-				Sensitive:true,
 				DefaultFunc: schema.EnvDefaultFunc("INFLUXDB_V2_TOKEN", ""),
 			},
 		},
@@ -42,8 +31,7 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	options := influxdb.WithUserAndPass(d.Get("username").(string), d.Get("password").(string))
-	influx, error := influxdb.New(d.Get("url").(string), d.Get("token").(string), options)
+	influx, error := influxdb.New(d.Get("url").(string), d.Get("token").(string))
 	if error != nil {
 		return nil, fmt.Errorf("invalid InfluxDBv2 URL: %s", error)
 	}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -18,14 +18,6 @@ The provider configuration block accepts the following arguments:
     * The root URL of a InfluxDB V2 server. May alternatively be set via the `INFLUXDB_V2_URL` environment variable.
     * Defaults to `http://localhost:9999/`.
     
-* ``username``
-   * (Optional)
-   * The username of the Influxdb V2 account. May alternatively be set via the `INFLUXDB_V2_USERNAME` environment variable.
-
-* ``password``
-   * (Optional)
-   * The password of the Influxdb V2 account. May alternatively be set via the `INFLUXDB_V2_PASSWORD` environment variable.
-
 * ``token``
    * (Optional)
    * The token of the Influwdb V2 account. May alternatively be set via the `INFLUXDB_V2_TOKEN` environment variable.
@@ -34,8 +26,6 @@ The provider configuration block accepts the following arguments:
 ```hcl
 provider "influxdbv2" {
   url = "http://influxdb.example.com:9999"
-  username = "influxdbUsername"
-  password = "influxdbPassword"
   token = "influxdbToken"
 }
  ```


### PR DESCRIPTION
The provider is now configured with the `url` and the `token` parameters. The documentation has been modified according to this. closes #4 